### PR TITLE
Fix btor2 file detection (and add unsupported file format error)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,14 @@ fn main() {
     if options.verbose > 0 {
         println!("the model to be checked: {}", options.model.display());
     }
-    let mut aig = if options.model.ends_with(".btor") || options.model.ends_with(".btor2") {
-        panic!(
+    let mut aig = match options.model.extension() {
+        Some(ext) if (ext == "btor") | (ext == "btor2") => panic!(
             "rIC3 currently does not support parsing BTOR2 files. Please use btor2aiger (https://github.com/hwmcc/btor2tools) to first convert them to AIG format."
-        )
-    } else {
-        Aig::from_file(options.model.to_str().unwrap())
+        ),
+        Some(ext) if (ext == "aig") | (ext == "aag") => {
+            Aig::from_file(options.model.to_str().unwrap())
+        }
+        _ => panic!("unsupported file format"),
     };
     if !aig.outputs.is_empty() && !options.certify {
         // not certifying, move outputs to bads


### PR DESCRIPTION
Hey, thanks for making rIC3 public, it's great to have such a performant tool available open-source!

It looks like there's a bug in the btor2 file detection at the moment, since you use the `ends_with` method [which only works on whole path components](https://doc.rust-lang.org/std/path/struct.Path.html#method.ends_with). This means that running rIC3 on a btor2 file will still feed it to the AIGER passer and crash out there, rather than with an informative error message.

This PR swaps to pattern matching on the result of the `extension` method which should fix that. Since I was changing it anyway, I also added in an error to trigger when another unsupported file format is given too. I'm not too familiar with Rust, so let me know if this implementation is undesirable for any reason!