### PR TITLE
Pass preprocessing options through to portfolio

### DIFF
--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -61,6 +61,12 @@ impl Portfolio {
             for a in args {
                 engine.arg(a);
             }
+            if option.preprocess.sec {
+                engine.arg("--sec");
+            }
+            if option.preprocess.no_abc {
+                engine.arg("--no-abc");
+            }
             engines.push(engine);
         };
         new_engine("-e ic3");


### PR DESCRIPTION
This passes `--no-abc` and `--sec` through to the portfolio engines as I have found that on some of my benchmarks abc always times out so I would like to disable it for them.