### PR TITLE
Command line accepts both 1 and 2 cert paths for seamless certifaiger compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 /target
-build/
+.cache
+# certifaiger output
+bugs
+bug.aag
+options
+# AI
+CLAUDE.md
+AGENTS.md
+.claude

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,8 +19,11 @@ pub struct Config {
     /// for btor model, the file name should be suffixed with .btor or .btor2.
     pub model: PathBuf,
 
-    /// certificate path
-    pub certificate: Option<PathBuf>,
+    /// SAT certificate path (counterexample). Also used for UNSAT if second path not specified.
+    pub sat_certificate: Option<PathBuf>,
+
+    /// UNSAT certificate path (invariant proof). If omitted, uses first certificate path.
+    pub unsat_certificate: Option<PathBuf>,
 
     /// certify with certifaiger or cerbtora
     #[arg(long, default_value_t = false)]

--- a/src/frontend/aig/mod.rs
+++ b/src/frontend/aig/mod.rs
@@ -165,7 +165,7 @@ impl AigFrontend {
             }
             if aig.bads.is_empty() {
                 warn!("no property to be checked");
-                if let Some(certificate) = &cfg.certificate {
+                if let Some(certificate) = &cfg.unsat_certificate {
                     let mut map = aig.inputs.clone();
                     map.extend(aig.latchs.iter().map(|l| l.input));
                     for x in map {

--- a/src/frontend/btor/mod.rs
+++ b/src/frontend/btor/mod.rs
@@ -86,7 +86,7 @@ impl BtorFrontend {
         let btor = Btor::from_file(&cfg.model);
         if btor.bad.is_empty() {
             warn!("no property to be checked");
-            if let Some(certificate) = &cfg.certificate {
+            if let Some(certificate) = &cfg.unsat_certificate {
                 btor.to_file(certificate);
             }
             println!("UNSAT");

--- a/src/portfolio/mod.rs
+++ b/src/portfolio/mod.rs
@@ -131,7 +131,7 @@ impl Portfolio {
         let lock = self.state.0.lock().unwrap();
         for mut engine in take(&mut self.engines) {
             let certificate =
-                if self.cfg.certificate.is_some() || self.cfg.certify || self.cfg.witness {
+                if self.cfg.sat_certificate.is_some() || self.cfg.certify || self.cfg.witness {
                     let certificate =
                         tempfile::NamedTempFile::new_in(self.temp_dir.path()).unwrap();
                     let certify_path = certificate.path().as_os_str().to_str().unwrap();
@@ -224,14 +224,14 @@ impl Portfolio {
 
     fn certificate(&mut self, cfg: &Config, res: bool) {
         if res {
-            if cfg.certificate.is_none() && !cfg.certify {
+            if cfg.unsat_certificate.is_none() && !cfg.certify {
                 return;
             }
-            if let Some(certificate_path) = &cfg.certificate {
+            if let Some(certificate_path) = &cfg.unsat_certificate {
                 std::fs::copy(self.certificate.as_ref().unwrap(), certificate_path).unwrap();
             }
         } else {
-            if cfg.certificate.is_none() && !cfg.certify && !cfg.witness {
+            if cfg.sat_certificate.is_none() && !cfg.certify && !cfg.witness {
                 return;
             }
             let mut witness = String::new();
@@ -250,7 +250,7 @@ impl Portfolio {
             if cfg.witness {
                 println!("{witness}");
             }
-            if let Some(certificate_path) = &cfg.certificate {
+            if let Some(certificate_path) = &cfg.sat_certificate {
                 let mut file: File = File::create(certificate_path).unwrap();
                 file.write_all(witness.as_bytes()).unwrap();
             }


### PR DESCRIPTION
Split certificate path to SAT and UNSAT separately, with one key difference:

```rust
    // If only sat_certificate is specified, use it for unsat_certificate too
    if cfg.unsat_certificate.is_none() && cfg.sat_certificate.is_some() {
        cfg.unsat_certificate = cfg.sat_certificate.clone();
    }
```

With this, the command line works seamlessly with both 1 and 2 cert paths.  
No need to cherry-pick the certifaiger commit just for running it, and existing use cases should not break.