### PR TITLE
Add MAB-guided IC3 generalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +999,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1373,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1419,37 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+dependencies = [
+ "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1424,6 +1498,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1529,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1776,6 +1870,7 @@ dependencies = [
  "linkme",
  "log",
  "logicrs",
+ "nalgebra",
  "nix 0.31.3",
  "rand 0.10.1",
  "ratatui",
@@ -1945,6 +2040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2211,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "satif-cadical"
@@ -2287,6 +2397,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "wide",
 ]
 
 [[package]]
@@ -2966,6 +3088,16 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ratatui = "0.30.0"
 anyhow = "1.0.101"
 ron = "0.12.0"
 regex = "1.12.3"
-strum = "0.28"
+strum = { version = "0.28", features = ["derive"] }
 tabled = { version = "0.21.0", features = ["ansi"] }
 vcd = "0.7.0"
 enum-as-inner = "0.7.0"
@@ -53,6 +53,7 @@ tokio = { version = "1.52.3", features = [
     "macros",
     "io-std",
 ] }
+nalgebra = "0.35.0"
 
 [profile.release]
 lto = true

--- a/src/ic3/block.rs
+++ b/src/ic3/block.rs
@@ -36,8 +36,13 @@ impl IC3 {
             self.add_obligation(po.clone());
             return self.add_lemma(po.frame - 1, po.state.as_litvec().clone(), false, Some(po));
         };
+        let original_cube_size = mic.len();
         mic = self.mic(po.frame, mic, &[], mic_type);
+        let generalized_cube_size = mic.len();
         let (frame, mic) = self.push_lemma(po.frame, mic);
+        if self.cfg.mab {
+            self.mab_feedback(&po, original_cube_size, generalized_cube_size, frame);
+        }
         self.statistic.avg_po_cube_len += po.state.len();
         po.push_to(frame);
         self.add_obligation(po.clone());
@@ -127,7 +132,9 @@ impl IC3 {
             self.statistic.block.blocked_time += blocked_start.elapsed();
             if blocked {
                 noc += 1;
-                let mic_type = if self.cfg.dynamic {
+                let mic_type = if self.cfg.mab {
+                    self.mab_choose_mic_type(&po)
+                } else if self.cfg.dynamic {
                     if let Some(mut n) = po.next.as_mut() {
                         let mut act = n.act;
                         for _ in 0..2 {

--- a/src/ic3/mab.rs
+++ b/src/ic3/mab.rs
@@ -273,10 +273,9 @@ impl IC3 {
         if po.frame as f64 > 0.7 * level as f64 && pushing_power > 0.0 {
             bonus += 0.1;
         }
-        let reward = (size_reduction_ratio * 0.35 + push_quality * 0.45
-            + generalization_quality
-            + bonus)
-            .clamp(-0.5, 2.0);
+        let reward =
+            (size_reduction_ratio * 0.35 + push_quality * 0.45 + generalization_quality + bonus)
+                .clamp(-0.5, 2.0);
         debug!("MAB arm {arm} got reward {reward:.2}");
         let ctx = self.mab_context_vector(po);
         self.mab.update(arm, &ctx, reward);

--- a/src/ic3/mab.rs
+++ b/src/ic3/mab.rs
@@ -1,0 +1,284 @@
+//! Contextual multi-armed bandit (PA-LinUCB) for adaptive inductive
+//! generalization strategy selection (A-IC3).
+//!
+//! Before each generalization, a proof-aware context vector is extracted from
+//! the IC3 state and a LinUCB agent selects among generalization strategies
+//! (arms) of varying aggressiveness. After generalization and the intermediate
+//! push, the agent receives a reward combining size reduction, push quality,
+//! and bonus events, and updates its linear model online.
+
+use crate::ic3::{
+    IC3,
+    mic::{DropVarParameter, MicType},
+    proofoblig::ProofObligation,
+};
+use log::{debug, warn};
+use nalgebra::{DMatrix, DVector};
+
+/// Dimension of the proof-aware context vector (6 features + bias).
+const CONTEXT_DIM: usize = 7;
+
+/// Dynamic (activity-aware) arms.
+const BALANCED_ARM: usize = 0;
+const AGGRESSIVE_ARM: usize = 1;
+const CONSERVATIVE_ARM: usize = 2;
+const NUM_DYNAMIC_ARMS: usize = 3;
+
+/// Static arms: fixed (limit, max, level) configurations of DropVarParameter.
+const FIXED_ARM_CONFIGS: [(usize, usize, usize); 4] = [
+    (0, 0, 0), // basic: no CTG
+    (1, 3, 1), // conservative CTG
+    (2, 5, 1), // balanced CTG
+    (8, 4, 1), // aggressive deep CTG
+];
+
+const NUM_ARMS: usize = NUM_DYNAMIC_ARMS + FIXED_ARM_CONFIGS.len();
+
+pub struct CtxMab {
+    alpha: f64,
+    lambda: f64,
+    a: Vec<DMatrix<f64>>,
+    a_inv: Vec<DMatrix<f64>>,
+    b: Vec<DVector<f64>>,
+    theta: Vec<DVector<f64>>,
+    arm_pulls: Vec<usize>,
+    avg_cube_size: f64,
+    cube_size_count: usize,
+    /// arm chosen for the generalization currently in flight
+    pending: Option<usize>,
+}
+
+impl CtxMab {
+    pub fn new(alpha: f64, lambda: f64) -> Self {
+        Self {
+            alpha,
+            lambda,
+            a: vec![DMatrix::identity(CONTEXT_DIM, CONTEXT_DIM); NUM_ARMS],
+            a_inv: vec![DMatrix::identity(CONTEXT_DIM, CONTEXT_DIM); NUM_ARMS],
+            b: vec![DVector::zeros(CONTEXT_DIM); NUM_ARMS],
+            theta: vec![DVector::zeros(CONTEXT_DIM); NUM_ARMS],
+            arm_pulls: vec![0; NUM_ARMS],
+            avg_cube_size: 0.0,
+            cube_size_count: 0,
+            pending: None,
+        }
+    }
+
+    /// LinUCB arm selection: argmax of theta^T x + alpha * sqrt(x^T A^-1 x).
+    fn select(&mut self, ctx: &DVector<f64>) -> usize {
+        let mut best_arm = 0;
+        let mut best_score = f64::NEG_INFINITY;
+        for arm in 0..NUM_ARMS {
+            let predicted = self.theta[arm].dot(ctx);
+            let uncertainty = (ctx.transpose() * &self.a_inv[arm] * ctx)[(0, 0)];
+            let score = predicted + self.alpha * uncertainty.max(0.0).sqrt();
+            if score > best_score {
+                best_score = score;
+                best_arm = arm;
+            }
+        }
+        self.arm_pulls[best_arm] += 1;
+        best_arm
+    }
+
+    /// LinUCB update: A += x x^T, b += r x, theta = (A + lambda I)^-1 b.
+    fn update(&mut self, arm: usize, ctx: &DVector<f64>, reward: f64) {
+        self.a[arm] += ctx * ctx.transpose();
+        self.b[arm] += ctx * reward;
+        let regularized = &self.a[arm] + DMatrix::identity(CONTEXT_DIM, CONTEXT_DIM) * self.lambda;
+        if let Some(inv) = regularized.try_inverse() {
+            self.theta[arm] = &inv * &self.b[arm];
+            self.a_inv[arm] = inv;
+        } else {
+            warn!("MAB: matrix A for arm {arm} became non-invertible, resetting arm");
+            self.a[arm] = DMatrix::identity(CONTEXT_DIM, CONTEXT_DIM);
+            self.a_inv[arm] = DMatrix::identity(CONTEXT_DIM, CONTEXT_DIM);
+            self.b[arm] = DVector::zeros(CONTEXT_DIM);
+            self.theta[arm] = DVector::zeros(CONTEXT_DIM);
+        }
+    }
+
+    pub fn statistic(&self) -> String {
+        format!("MAB arm pulls: {:?}", self.arm_pulls)
+    }
+}
+
+/// Max activity along the successor chain of the po (up to 3 hops), used by
+/// the dynamic arms to gauge the difficulty of blocking the current CTI.
+fn branch_act(po: &ProofObligation) -> Option<f64> {
+    let mut n = po.next.as_ref()?;
+    let mut act = n.act;
+    for _ in 0..2 {
+        if let Some(nn) = n.next.as_ref() {
+            n = nn;
+            act = act.max(n.act);
+        } else {
+            break;
+        }
+    }
+    Some(act)
+}
+
+/// Balanced dynamic arm: the original DynAMic activity mapping.
+fn balanced_params(po: &ProofObligation) -> DropVarParameter {
+    let Some(act) = branch_act(po) else {
+        return DropVarParameter::default();
+    };
+    match act {
+        40.0.. => {
+            let limit = ((act - 40.0).powf(0.3) * 2.0 + 5.0).round() as usize;
+            DropVarParameter::new(limit, 5, 1)
+        }
+        10.0..40.0 => {
+            let max = (act - 10.0) as usize / 10 + 2;
+            DropVarParameter::new(1, max, 1)
+        }
+        _ => DropVarParameter::new(0, 0, 0),
+    }
+}
+
+/// Aggressive dynamic arm: lower thresholds, stronger generalization effort.
+fn aggressive_params(po: &ProofObligation) -> DropVarParameter {
+    let Some(act) = branch_act(po) else {
+        return DropVarParameter::new(1, 1, 1);
+    };
+    match act {
+        25.0.. => {
+            let limit = ((act - 25.0).powf(0.3) * 2.5 + 6.0).round() as usize;
+            DropVarParameter::new(limit, 6, 1)
+        }
+        5.0..25.0 => {
+            let max = (act - 5.0) as usize / 8 + 3;
+            DropVarParameter::new(2, max, 1)
+        }
+        _ => DropVarParameter::new(1, 1, 1),
+    }
+}
+
+/// Conservative dynamic arm: higher thresholds, capped generalization effort.
+fn conservative_params(po: &ProofObligation) -> DropVarParameter {
+    let Some(act) = branch_act(po) else {
+        return DropVarParameter::default();
+    };
+    match act {
+        50.0.. => {
+            let limit = (((act - 50.0).powf(0.3) * 1.5 + 4.0).round() as usize).min(6);
+            DropVarParameter::new(limit, 3, 1)
+        }
+        15.0..50.0 => {
+            let max = ((act - 15.0) as usize / 12 + 1).min(3);
+            DropVarParameter::new(1, max, 0)
+        }
+        _ => DropVarParameter::new(0, 0, 0),
+    }
+}
+
+impl IC3 {
+    /// Proof-aware context vector: [relative level, relative cube size,
+    /// push potential, relative depth, frame saturation, activity, bias].
+    /// Also maintains the running average cube size used for normalization.
+    fn mab_context_vector(&mut self, po: &ProofObligation) -> DVector<f64> {
+        let relative_level = po.frame as f64 / self.level() as f64;
+        let mab = &mut self.mab;
+        let total_cube_size = mab.cube_size_count as f64 * mab.avg_cube_size;
+        mab.cube_size_count += 1;
+        mab.avg_cube_size = (total_cube_size + po.state.len() as f64) / mab.cube_size_count as f64;
+        let relative_cube_size = po.state.len() as f64 / mab.avg_cube_size.max(1.0);
+        let potential_of_push = 1.0 - relative_level;
+        let relative_depth = po.frame as f64 / (po.frame + po.depth) as f64;
+        let saturation = if po.frame < self.frame.len() && !self.frame[po.frame].is_empty() {
+            self.frame[po.frame][0].len()
+        } else {
+            0
+        };
+        let frame_saturation = (saturation as f64 / 100.0).min(1.0);
+        let act_feat = (po.act / 100.0).clamp(0.0, 1.0);
+        DVector::from_column_slice(&[
+            relative_level,
+            relative_cube_size,
+            potential_of_push,
+            relative_depth,
+            frame_saturation,
+            act_feat,
+            1.0,
+        ])
+    }
+
+    /// Select a generalization strategy with LinUCB and record it as pending
+    /// until the matching `mab_feedback` after generalization.
+    pub(super) fn mab_choose_mic_type(&mut self, po: &ProofObligation) -> MicType {
+        let ctx = self.mab_context_vector(po);
+        let arm = self.mab.select(&ctx);
+        self.mab.pending = Some(arm);
+        let p = match arm {
+            BALANCED_ARM => balanced_params(po),
+            AGGRESSIVE_ARM => aggressive_params(po),
+            CONSERVATIVE_ARM => conservative_params(po),
+            _ => {
+                let (limit, max, level) = FIXED_ARM_CONFIGS[arm - NUM_DYNAMIC_ARMS];
+                DropVarParameter::new(limit, max, level)
+            }
+        };
+        debug!("MAB chose arm {arm}: {p:?}");
+        MicType::DropVar(p)
+    }
+
+    /// Compute the reward of the pending arm from the generalization outcome
+    /// and update the LinUCB model.
+    pub(super) fn mab_feedback(
+        &mut self,
+        po: &ProofObligation,
+        original_cube_size: usize,
+        generalized_cube_size: usize,
+        pushed_frame: usize,
+    ) {
+        let Some(arm) = self.mab.pending.take() else {
+            return;
+        };
+        let level = self.level();
+        let pushing_power = pushed_frame as f64 - po.frame as f64;
+        let size_reduction_ratio = if original_cube_size > 0 {
+            (original_cube_size as f64 - generalized_cube_size as f64) / original_cube_size as f64
+        } else {
+            0.0
+        };
+        let max_possible_push = level as f64 - po.frame as f64 + 1.0;
+        let pushing_power_ratio = if max_possible_push > 0.0 {
+            pushing_power / max_possible_push
+        } else {
+            0.0
+        };
+        // push quality: reward effective pushes, penalize unpushable clauses
+        let push_quality = if pushing_power > 0.0 {
+            pushing_power_ratio
+        } else {
+            -0.1
+        };
+        // ideal vs over-generalization
+        let generalization_quality = if size_reduction_ratio > 0.5 && pushing_power_ratio > 0.3 {
+            0.3
+        } else if size_reduction_ratio > 0.7 && pushing_power_ratio < 0.1 {
+            -0.2
+        } else {
+            0.0
+        };
+        // bonus events: frontier push, complete generalization, high-level push
+        let mut bonus = 0.0;
+        if pushed_frame >= level {
+            bonus += 0.4;
+        }
+        if generalized_cube_size == 1 {
+            bonus += 0.2;
+        }
+        if po.frame as f64 > 0.7 * level as f64 && pushing_power > 0.0 {
+            bonus += 0.1;
+        }
+        let reward = (size_reduction_ratio * 0.35 + push_quality * 0.45
+            + generalization_quality
+            + bonus)
+            .clamp(-0.5, 2.0);
+        debug!("MAB arm {arm} got reward {reward:.2}");
+        let ctx = self.mab_context_vector(po);
+        self.mab.update(arm, &ctx, reward);
+    }
+}

--- a/src/ic3/mod.rs
+++ b/src/ic3/mod.rs
@@ -28,6 +28,7 @@ mod auxv;
 mod block;
 mod frame;
 mod localabs;
+mod mab;
 mod mic;
 mod predprop;
 mod proofoblig;
@@ -47,6 +48,18 @@ pub struct IC3Config {
     /// dynamic generalization
     #[arg(long = "dynamic", default_value_t = false)]
     pub dynamic: bool,
+
+    /// contextual-MAB (LinUCB) adaptive generalization (A-IC3)
+    #[arg(long = "mab", default_value_t = false)]
+    pub mab: bool,
+
+    /// LinUCB exploration parameter alpha
+    #[arg(long = "mab-alpha", default_value_t = 1.0)]
+    pub mab_alpha: f64,
+
+    /// LinUCB regularization parameter lambda
+    #[arg(long = "mab-lambda", default_value_t = 0.1)]
+    pub mab_lambda: f64,
 
     /// counterexample to generalization
     #[arg(long = "ctg", action = ArgAction::Set, default_value_t = true)]
@@ -118,6 +131,10 @@ impl IC3Config {
             error!("cannot enable both dynamic and drop-po");
             panic!();
         }
+        if self.mab && self.drop_po {
+            error!("cannot enable both mab and drop-po");
+            panic!();
+        }
         if self.inn {
             let pre = "cannot enable both inn and";
             if self.abs_cst || self.abs_trans {
@@ -165,6 +182,7 @@ pub struct IC3 {
     rst: Restore,
     auxiliary_var: Vec<Var>,
     predprop: Option<PredProp>,
+    mab: mab::CtxMab,
 
     rng: StdRng,
     filog: IntervalLogger,
@@ -240,6 +258,7 @@ impl IC3 {
         let inf_solver = TransysSolver::new(&tsctx);
         let lift = TsLift::new(TransysUnroll::new(&ts));
         let localabs = LocalAbs::new(&ts, &cfg);
+        let mab = mab::CtxMab::new(cfg.mab_alpha, cfg.mab_lambda);
         Self {
             cfg,
             ts,
@@ -258,6 +277,7 @@ impl IC3 {
             ots,
             rst,
             predprop,
+            mab,
             rng,
             filog: Default::default(),
             tracer: Tracer::new(),
@@ -354,6 +374,9 @@ impl Engine for IC3 {
 
     fn statistic(&mut self) {
         self.statistic.num_auxiliary_var = self.auxiliary_var.len();
+        if self.cfg.mab {
+            info!("{}", self.mab.statistic());
+        }
         info!("obligations: {}", self.obligations.statistic());
         info!("{}", self.frame.statistic(false));
         let mut statistic = SolverStatistic::default();


### PR DESCRIPTION
## Summary

This PR updates rIC3 with the MAB-IC3 algorithm from the CAV 2026 work:

https://arxiv.org/abs/2604.21688

The implementation adds a contextual multi-armed bandit based generalization strategy selector for IC3. During blocking, IC3 extracts proof-aware context from the current proof obligation, uses LinUCB to select a MIC/generalization strategy, then updates the bandit model using feedback from lemma size reduction and push effectiveness.

## Usage

### CLI

Run IC3 with MAB-guided generalization:

```bash
ric3 check <model.aig> ic3 --mab --drop-po=false
```

Optional tuning parameters:

```bash
ric3 check <model.aig> ic3 --mab --drop-po=false --mab-alpha 1.0 --mab-lambda 0.1
```

`--drop-po=false` is required because MAB and proof-obligation dropping are mutually exclusive.

### Portfolio

To use MAB-IC3 in a portfolio, add an IC3 worker configuration that enables MAB:

```toml
ic3_mab = "ic3 --mab --drop-po=false"
```

For example, add it to the desired portfolio section in `src/portfolio/portfolio.toml`, then run:

```bash
ric3 check <model.aig> portfolio --config <portfolio-config-name>
```
